### PR TITLE
Fix CircleCI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/shannonrothe/wind.svg?style=shield&circle-token=fbfe23d0079bcc5ab8d1f110cc75b438befccc9b)](https://circleci.com/gh/shannonrothe/wind.svg?style=shield&circle-token=fbfe23d0079bcc5ab8d1f110cc75b438befccc9b)
+[![CircleCI](https://circleci.com/gh/shannonrothe/wind.svg?style=shield)](https://circleci.com/gh/shannonrothe/wind)
 
 # Wind
 


### PR DESCRIPTION
Updated the URL for the Circle CI badge, so the click location goes to Circle CI